### PR TITLE
Fix breaks.handlebars so new breaks will be added to the table.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "express": "~4.15.5",
     "express-handlebars": "^3.0.0",
     "handlebars": "^4.0.11",
-    "handlebars-loader": "^1.6.0",
     "node-sass": "^4.7.2",
     "python-shell": "^0.4.0",
     "serve-favicon": "~2.4.5"

--- a/views/partials/breaks.handlebars
+++ b/views/partials/breaks.handlebars
@@ -18,4 +18,13 @@
     </div>
 
   </div>
+
+  <table>
+    <tr>
+      <th>Name</th>
+      <th>Length (in minutes)</th>
+      <th>Start Time</th>
+      <th>End Time</th>
+    </tr>
+  </table>
 </div>


### PR DESCRIPTION
The table header is now displayed by default. Also takes handlebars-loader out of dependencies but leaves it in devDependencies.